### PR TITLE
docs: document build prerequisites

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,19 @@
+# Development Setup
+
+Install the following tools before working with this repository:
+
+- **Node.js 22.17.0** – specified in `.nvmrc` and required for building.
+- **Yarn** – used to manage Node.js dependencies.
+- **Python 3** – required for native build scripts.
+- **C/C++ build tools**
+  - Linux: `gcc`, `g++`, `make`, and related packages (e.g. `build-essential`).
+  - macOS: Xcode Command Line Tools.
+  - Windows: Visual Studio Build Tools with the C++ workload.
+
+With the prerequisites installed, install dependencies and start a development build:
+
+```bash
+yarn
+yarn watch
+yarn web
+```


### PR DESCRIPTION
## Summary
- document Node.js, Python, and build tool requirements

## Testing
- `node -v`
- `python3 --version`
- `yarn`
- `yarn watch` *(fails: package not in lockfile; run "yarn install" to update)*
- `yarn web` *(fails: package not in lockfile; run "yarn install" to update)*

------
https://chatgpt.com/codex/tasks/task_e_68a02553a21c8322a8d2f8b179270123