### PR TITLE
chore: store icons via git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,10 @@
 * text=auto
-
 LICENSE.txt eol=crlf
 ThirdPartyNotices.txt eol=crlf
-
 *.bat eol=crlf
 *.cmd eol=crlf
 *.ps1 eol=lf
 *.sh eol=lf
 *.rtf -text
 **/*.json linguist-language=jsonc
+resources/*.png filter=lfs diff=lfs merge=lfs -text

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,4 @@
+# Branding Assets
+
+Icon image assets in the `resources` folder are managed using [Git LFS](https://git-lfs.com/) to keep the repository lightweight.
+

--- a/resources/icon-linux.png
+++ b/resources/icon-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51653af6534e0637d91b55ebd5f63f989302071d67a0724e48adfc16624b0a7
+size 2721

--- a/resources/icon-server.png
+++ b/resources/icon-server.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51653af6534e0637d91b55ebd5f63f989302071d67a0724e48adfc16624b0a7
+size 2721


### PR DESCRIPTION
## Summary
- track `resources/*.png` with Git LFS
- add icon binaries managed by LFS
- document icon management in branding docs

## Testing
- `npm test`
- `git push` *(fails: No configured push destination)*
- `git lfs push --all` *(fails: Specify a remote and a remote branch name)*

------
https://chatgpt.com/codex/tasks/task_e_68a02a72b2948322ab086a9121b3af29