### PR TITLE
feat: add capitalize utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Added `capitalize` utility to `src/vs/base/common/strings.ts`.

--- a/docs/features/string-capitalize.md
+++ b/docs/features/string-capitalize.md
@@ -1,0 +1,3 @@
+# String Capitalize
+
+Adds a utility `capitalize` to `src/vs/base/common/strings.ts` that converts the first character of a string to uppercase while leaving the rest of the string unchanged. If the string is empty, it is returned unchanged.

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -193,7 +193,14 @@ export function convertSimple2RegExpPattern(pattern: string): string {
 }
 
 export function stripWildcards(pattern: string): string {
-	return pattern.replace(/\*/g, '');
+        return pattern.replace(/\*/g, '');
+}
+
+export function capitalize(str: string): string {
+        if (!str) {
+                return str;
+        }
+        return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export interface RegExpOptions {

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -618,6 +618,13 @@ suite('Strings', () => {
 		assert.strictEqual(strings.removeAnsiEscapeCodesFromPrompt('\n\\[\u001b[01;34m\\]\\w\\[\u001b[00m\\]\n\\[\u001b[1;32m\\]> \\[\u001b[0m\\]'), '\n\\w\n> ');
 	});
 
+        test('capitalize', () => {
+                assert.strictEqual(strings.capitalize('foo'), 'Foo');
+                assert.strictEqual(strings.capitalize('Foo'), 'Foo');
+                assert.strictEqual(strings.capitalize(''), '');
+                assert.strictEqual(strings.capitalize('f'), 'F');
+        });
+
 	test('count', () => {
 		assert.strictEqual(strings.count('hello world', 'o'), 2);
 		assert.strictEqual(strings.count('hello world', 'l'), 3);


### PR DESCRIPTION
## Summary
- add `capitalize` helper to `strings` common module
- document new string utility
- cover `capitalize` in unit tests and changelog

## Testing
- `npm test`
- `npm run test-node -- -g Strings` *(fails: sh: 1: mocha: not found)*
- `npm run precommit` *(fails: Cannot find module 'gulp-filter')*


------
https://chatgpt.com/codex/tasks/task_e_68a0e529e5d48322ad119017794bb325