### PR TITLE
chore: add curated sample extension

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -29,10 +29,11 @@ const ext = require('./lib/extensions');
 // });
 const compilations = [
 	'extensions/configuration-editing/tsconfig.json',
-	'extensions/css-language-features/client/tsconfig.json',
-	'extensions/css-language-features/server/tsconfig.json',
-	'extensions/debug-auto-launch/tsconfig.json',
-	'extensions/debug-server-ready/tsconfig.json',
+'extensions/css-language-features/client/tsconfig.json',
+'extensions/css-language-features/server/tsconfig.json',
+'extensions/curated-sample/tsconfig.json',
+'extensions/debug-auto-launch/tsconfig.json',
+'extensions/debug-server-ready/tsconfig.json',
 	'extensions/emmet/tsconfig.json',
 	'extensions/extension-editing/tsconfig.json',
 	'extensions/git/tsconfig.json',

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,19 @@
+# Bundled Extensions
+
+The repository bundles curated extensions under the `extensions/` folder. Each extension declares its dependencies and configuration to ensure consistent builds.
+
+## `vscode.curated-sample`
+
+- **Purpose**: Demonstrates how an in-house curated extension can be bundled and configured.
+- **Dependencies**: Requires the built-in `vscode.git` extension.
+- **Configuration**:
+  - `curatedSample.enable` &ndash; boolean, enables Curated Sample features (default: `true`).
+
+### Scaffolding new integrations
+
+For new in-house integrations, scaffold extensions using the Yeoman generator:
+
+```sh
+npm install -g yo generator-code
+yo code
+```

--- a/extensions/curated-sample/README.md
+++ b/extensions/curated-sample/README.md
@@ -1,0 +1,3 @@
+# Curated Sample Extension
+
+An example curated extension bundled with the codebase. It depends on the built-in Git extension and provides a sample configuration option `curatedSample.enable` to toggle its features.

--- a/extensions/curated-sample/package.json
+++ b/extensions/curated-sample/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "curated-sample",
+  "displayName": "Curated Sample",
+  "publisher": "vscode",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "*"
+  ],
+  "extensionDependencies": [
+    "vscode.git"
+  ],
+  "contributes": {
+    "configuration": {
+      "title": "Curated Sample",
+      "properties": {
+        "curatedSample.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Curated Sample features."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "gulp compile-extension:curated-sample",
+    "watch": "gulp watch-extension:curated-sample"
+  }
+}

--- a/extensions/curated-sample/src/extension.ts
+++ b/extensions/curated-sample/src/extension.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+    console.log('Curated Sample extension is now active!');
+}
+
+export function deactivate() {}

--- a/extensions/curated-sample/tsconfig.json
+++ b/extensions/curated-sample/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./out"
+    },
+    "include": [
+        "src/**/*",
+        "../../src/vscode-dts/vscode.d.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- add curated sample extension with git dependency and config
- document bundled extensions and scaffolding via `yo code`
- compile curated extension with gulp

## Testing
- `npm test`
- `npx gulp compile-extension:curated-sample` *(fails: 403 Forbidden - GET https://registry.npmjs.org/gulp)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1fb10ec8322b7a9bae6ff865ee7