### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Build Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x64
+            artifact: vscode-linux-x64
+          - os: macos-latest
+            platform: darwin
+            artifact: vscode-darwin
+          - os: windows-latest
+            platform: win32-x64
+            artifact: vscode-win32-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: yarn gulp vscode-${{ matrix.platform }}
+      - name: Sign build
+        run: ./scripts/sign-${{ matrix.platform }}.sh .build/${{ matrix.artifact }}
+        env:
+          SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: .build/${{ matrix.artifact }}/**
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: '**/*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,27 @@
+# Release Process
+
+This document describes how to build and publish signed releases for VS Code.
+
+## Preparing a Release
+1. Ensure the `main` branch is up to date and that CI passes.
+2. Update version numbers and changelog as needed.
+3. Create a tag `vX.Y.Z` and push it to GitHub.
+
+## Build and Test
+The [release workflow](../.github/workflows/release.yml) runs automatically for tags and on demand. It:
+
+1. Installs dependencies with `yarn --frozen-lockfile`.
+2. Runs unit tests using `npm test`.
+3. Builds the product with `yarn gulp vscode-{platform}` for:
+   - `win32-x64` on Windows
+   - `darwin` on macOS
+   - `linux-x64` on Linux
+
+## Signing
+Each build is signed using platform-specific scripts invoked by the workflow. Signing certificates and keys are supplied through repository secrets.
+
+## Publishing
+Built archives are uploaded as workflow artifacts. When the workflow is triggered by a tag, a release job publishes those artifacts to GitHub Releases. The same artifacts can also be pushed to an internal package registry if required.
+
+## Manual Distribution
+After the workflow completes, download installers or archives from the release and distribute them through the approved channels.


### PR DESCRIPTION
## Summary
- add release workflow building and signing platform packages
- document release process and publishing steps

## Testing
- `npm test`
- `npm run precommit` *(fails: Cannot find module 'gulp-filter')*

------
https://chatgpt.com/codex/tasks/task_e_68a167feeb348322b7964f83ff1a1a49