### PR TITLE
docs: add chat architecture overview

### DIFF
--- a/docs/chat/architecture.md
+++ b/docs/chat/architecture.md
@@ -1,0 +1,47 @@
+---
+title: Chat Architecture
+---
+
+# Chat Architecture
+
+This document outlines the flow of a chat request.
+
+The chat flow is: editor context → API request → response rendering.
+
+## Request and Response
+
+```mermaid
+sequenceDiagram
+    participant Editor as Editor
+    participant Service as ChatService
+    participant API as LanguageModelAPI
+    participant View as ChatUI
+
+    Editor->>Service: Gather context
+    Service->>API: Send request
+    API-->>Service: Return response
+    Service-->>View: Render message
+```
+
+## Error Handling
+
+```mermaid
+sequenceDiagram
+    participant Editor as Editor
+    participant Service as ChatService
+    participant API as LanguageModelAPI
+    participant View as ChatUI
+
+    Editor->>Service: Gather context
+    Service->>API: Send request
+    API--x Service: Error
+    Service-->>View: Display error
+```
+
+## Related Services and Modules
+
+- `src/vs/workbench/contrib/chat/common/chatService.ts`
+- `src/vs/workbench/contrib/chat/common/chatServiceImpl.ts`
+- `src/vs/workbench/contrib/chat/browser/chatWidget.ts`
+- `src/vs/workbench/contrib/chat/browser/chatViewPane.ts`
+


### PR DESCRIPTION
## Summary
- document chat flow from editor context to API and rendering
- include request/response and error handling sequence diagrams
- reference planned chat services and UI modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c54d6f188322b9e40cfe09936272