### PR TITLE
feat: add OpenAI chat client

### DIFF
--- a/src/services/openai/client.test.ts
+++ b/src/services/openai/client.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sendChat, OpenAIError } from './client.ts';
+import { ReadableStream } from 'node:stream/web';
+
+const encoder = new TextEncoder();
+
+function streamFromLines(lines: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line));
+      }
+      controller.close();
+    }
+  });
+}
+
+test('sendChat returns non-streaming response', async () => {
+  const body = { choices: [{ message: { role: 'assistant', content: 'Hello' } }] };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+  const res = await sendChat([{ role: 'user', content: 'Hi' }]);
+  assert.equal(res.content, 'Hello');
+  globalThis.fetch = originalFetch;
+});
+
+test('sendChat parses streaming responses', async () => {
+  const lines = [
+    'data: {"choices":[{"delta":{"content":"Hel"}}]}\n',
+    'data: {"choices":[{"delta":{"content":"lo"}}]}\n',
+    'data: [DONE]\n'
+  ];
+  const stream = streamFromLines(lines);
+  const response = new Response(stream, { headers: { 'content-type': 'text/event-stream' } });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => response;
+  const res = await sendChat([{ role: 'user', content: 'Hi' }]);
+  assert.equal(res.content, 'Hello');
+  globalThis.fetch = originalFetch;
+});
+
+test('sendChat normalizes errors', async () => {
+  const body = { error: { message: 'Bad request' } };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(body), { status: 400, headers: { 'content-type': 'application/json' } });
+  await assert.rejects(() => sendChat([{ role: 'user', content: 'Hi' }]), (err: any) => err instanceof OpenAIError && err.status === 400 && err.message === 'Bad request');
+  globalThis.fetch = originalFetch;
+});
+

--- a/src/services/openai/client.ts
+++ b/src/services/openai/client.ts
@@ -1,0 +1,104 @@
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatResponse {
+  role: 'assistant';
+  content: string;
+}
+
+export class OpenAIError extends Error {
+  status?: number;
+  data?: any;
+  constructor(message: string, status?: number, data?: any) {
+    super(message);
+    this.name = 'OpenAIError';
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const API_URL = 'https://api.openai.com/v1/chat/completions';
+const API_KEY = process.env.VITE_OPENAI_API_KEY;
+
+export async function sendChat(messages: ChatMessage[]): Promise<ChatResponse> {
+  try {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${API_KEY ?? ''}`,
+      },
+      body: JSON.stringify({ model: 'gpt-3.5-turbo', stream: true, messages }),
+    });
+
+    if (!res.ok) {
+      let errData: any;
+      try {
+        errData = await res.json();
+      } catch {
+        errData = await res.text();
+      }
+      const msg = errData?.error?.message || res.statusText;
+      throw new OpenAIError(msg, res.status, errData);
+    }
+
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('stream')) {
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let message = '';
+      let buffer = '';
+      if (reader) {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('data:')) continue;
+            const data = trimmed.replace(/^data:\s*/, '');
+            if (data === '[DONE]') {
+              reader.cancel();
+              return { role: 'assistant', content: message };
+            }
+            try {
+              const json = JSON.parse(data);
+              const delta = json.choices?.[0]?.delta?.content;
+              if (delta) message += delta;
+            } catch {
+              // ignore parse errors
+            }
+          }
+        }
+        if (buffer.length) {
+          const trimmed = buffer.trim();
+          if (trimmed.startsWith('data:')) {
+            const data = trimmed.replace(/^data:\s*/, '');
+            try {
+              const json = JSON.parse(data);
+              const delta = json.choices?.[0]?.delta?.content;
+              if (delta) message += delta;
+            } catch {
+              // ignore
+            }
+          }
+        }
+      }
+      return { role: 'assistant', content: message };
+    } else {
+      const data = await res.json();
+      const message = data.choices?.[0]?.message ?? { role: 'assistant', content: '' };
+      return message;
+    }
+  } catch (err: any) {
+    if (err instanceof OpenAIError) {
+      throw err;
+    }
+    throw new OpenAIError(err?.message || 'OpenAI request failed');
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `sendChat` for OpenAI with streaming support and normalized errors
- add unit tests for success, streaming, and error cases

## Testing
- `node --experimental-strip-types --test src/services/openai/client.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d82bb0c88322a51a7027eca1f9ac