### PR TITLE
feat: add workspace context collector

### DIFF
--- a/src/services/context/context.test.ts
+++ b/src/services/context/context.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { collectWorkspaceContext, buildPromptWithContext } from './context.ts';
+
+function editor(fileName: string, content: string, selected?: string) {
+  return {
+    document: {
+      fileName,
+      getText(range?: any) {
+        if (range) {
+          return selected ?? '';
+        }
+        return content;
+      }
+    },
+    selection: selected ? {} : undefined
+  } as any;
+}
+
+test('collectWorkspaceContext summarizes files and selections', async () => {
+  const editors = [
+    editor('/foo.ts', 'one\ntwo\nthree', 'two'),
+    editor('/bar.ts', 'alpha\nbeta')
+  ];
+  const ctx = await collectWorkspaceContext(editors);
+  assert.match(ctx, /Filename: .*foo\.ts/);
+  assert.match(ctx, /one/);
+  assert.match(ctx, /Selected Text:\ntwo/);
+  assert.match(ctx, /Filename: .*bar\.ts/);
+});
+
+test('buildPromptWithContext combines prompt and context', async () => {
+  const editors = [editor('/baz.ts', 'content')];
+  const prompt = await buildPromptWithContext('Say hi', editors);
+  assert.match(prompt, /Say hi/);
+  assert.match(prompt, /Context:/);
+  assert.match(prompt, /content/);
+});
+
+test('collectWorkspaceContext truncates after 200 lines', async () => {
+  const longContent = Array.from({ length: 210 }, (_, i) => `line${i + 1}`).join('\n');
+  const editors = [editor('/long.ts', longContent)];
+  const ctx = await collectWorkspaceContext(editors);
+  assert.match(ctx, /line200/);
+  assert.doesNotMatch(ctx, /line201/);
+  assert.match(ctx, /\.\.\./);
+});

--- a/src/services/context/context.ts
+++ b/src/services/context/context.ts
@@ -1,0 +1,55 @@
+const MAX_LINES = 200;
+
+interface TextEditorLike {
+  document: {
+    fileName: string;
+    getText(range?: any): string;
+  };
+  selection?: any;
+}
+
+/**
+ * Collects a summary of the currently open editors in the workspace.
+ * The summary includes each file's name, the first {@link MAX_LINES} lines
+ * of its content, and any selected text.
+ */
+export async function collectWorkspaceContext(editors?: readonly TextEditorLike[]): Promise<string> {
+  if (!editors) {
+    try {
+      const vscode = await import('vscode');
+      editors = vscode.window.visibleTextEditors as readonly TextEditorLike[];
+    } catch {
+      editors = [];
+    }
+  }
+
+  const parts: string[] = [];
+  for (const editor of editors ?? []) {
+    const fileName = editor.document.fileName;
+    const fullText = editor.document.getText();
+    const lines = fullText.split(/\r?\n/);
+    let snippet = lines.slice(0, MAX_LINES).join('\n');
+    if (lines.length > MAX_LINES) {
+      snippet += '\n...';
+    }
+    let section = `Filename: ${fileName}\n${snippet}`;
+    const selected = editor.document.getText(editor.selection);
+    if (selected) {
+      section += `\nSelected Text:\n${selected}`;
+    }
+    parts.push(section);
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Builds a prompt by appending workspace context to the user's input.
+ */
+export async function buildPromptWithContext(userPrompt: string, editors?: readonly TextEditorLike[]): Promise<string> {
+  const context = await collectWorkspaceContext(editors);
+  if (!context) {
+    return userPrompt;
+  }
+  return `${userPrompt}\n\nContext:\n${context}`;
+}
+


### PR DESCRIPTION
## Summary
- add utility to collect open file context and selections
- expose `buildPromptWithContext` helper to append collected context to prompts
- cover workspace context logic with basic tests

## Testing
- `npm test`
- `node --test src/services/openai/client.test.ts src/services/context/context.test.ts` *(fails: Unknown file extension ".ts" for test files)*

------
https://chatgpt.com/codex/tasks/task_e_68a2569082c08322b9161c992a958e91