### PR TITLE
feat: add simple chat side panel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -117,6 +117,7 @@ import { PromptUrlHandler } from './promptSyntax/promptUrlHandler.js';
 import { SAVE_TO_PROMPT_ACTION_ID, SAVE_TO_PROMPT_SLASH_COMMAND_NAME } from './promptSyntax/saveToPromptAction.js';
 import { ConfigureToolSets, UserToolSetsContributions } from './tools/toolSetsContribution.js';
 import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.js';
+import './simpleChat.contribution.js';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);

--- a/src/vs/workbench/contrib/chat/browser/media/simpleChat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/simpleChat.css
@@ -1,0 +1,38 @@
+.simple-chat-root {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+}
+
+.simple-chat-messages {
+        flex: 1;
+        overflow-y: auto;
+        padding: 6px;
+}
+
+.simple-chat-input {
+        display: flex;
+        padding: 6px;
+}
+
+.simple-chat-input .monaco-inputbox {
+        flex: 1;
+}
+
+.simple-chat-send {
+        margin-left: 4px;
+}
+
+.simple-chat-message {
+        margin-bottom: 8px;
+}
+
+.simple-chat-message.error {
+        color: var(--vscode-errorForeground);
+}
+
+.simple-chat-latency {
+        opacity: 0.7;
+        font-size: 0.9em;
+        margin-top: 4px;
+}

--- a/src/vs/workbench/contrib/chat/browser/simpleChat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/simpleChat.contribution.ts
@@ -1,0 +1,28 @@
+import { localize } from '../../../../nls.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { IViewContainersRegistry, IViewsRegistry, Extensions as ViewContainerExtensions, ViewContainerLocation, ViewContainer } from '../../../common/views.js';
+import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
+import { SimpleChatViewPane } from './simpleChatView.js';
+
+export const SIMPLE_CHAT_VIEW_CONTAINER_ID = 'workbench.view.simpleChat';
+export const SIMPLE_CHAT_VIEW_ID = 'workbench.view.simpleChat.view';
+
+const viewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
+        id: SIMPLE_CHAT_VIEW_CONTAINER_ID,
+        title: localize('simpleChat', "Simple Chat"),
+        icon: Codicon.commentDiscussion,
+        ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [SIMPLE_CHAT_VIEW_CONTAINER_ID, { mergeViewWithContainerWhenSingleView: true }]),
+        order: 0,
+}, ViewContainerLocation.Sidebar);
+
+Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([
+        {
+                id: SIMPLE_CHAT_VIEW_ID,
+                name: localize('simpleChatView', "Simple Chat"),
+                ctorDescriptor: new SyncDescriptor(SimpleChatViewPane),
+                canMoveView: true,
+                canToggleVisibility: true,
+        }
+], viewContainer);

--- a/src/vs/workbench/contrib/chat/browser/simpleChatView.ts
+++ b/src/vs/workbench/contrib/chat/browser/simpleChatView.ts
@@ -1,0 +1,101 @@
+import { $, append } from '../../../../base/browser/dom.js';
+import { InputBox } from '../../../../base/browser/ui/inputbox/inputBox.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IViewDescriptorService } from '../../../common/views.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { ViewPane, IViewPaneOptions } from '../../../browser/parts/views/viewPane.js';
+import { ChatMarkdownRenderer } from './chatMarkdownRenderer.js';
+import { localize } from '../../../../nls.js';
+import './media/simpleChat.css';
+
+export class SimpleChatViewPane extends ViewPane {
+        private messages!: HTMLElement;
+        private input!: InputBox;
+        private renderer: ChatMarkdownRenderer;
+
+        constructor(
+                options: IViewPaneOptions,
+                @IKeybindingService keybindingService: IKeybindingService,
+                @IContextMenuService contextMenuService: IContextMenuService,
+                @IConfigurationService configurationService: IConfigurationService,
+                @IContextKeyService contextKeyService: IContextKeyService,
+                @IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+                @IInstantiationService instantiationService: IInstantiationService,
+                @IOpenerService openerService: IOpenerService,
+                @IThemeService themeService: IThemeService,
+                @IHoverService hoverService: IHoverService,
+                @IContextViewService private readonly contextViewService: IContextViewService,
+        ) {
+                super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
+
+                this.renderer = instantiationService.createInstance(ChatMarkdownRenderer, {});
+        }
+
+        protected override renderBody(container: HTMLElement): void {
+                const root = append(container, $('.simple-chat-root'));
+                const messages = append(root, $('.simple-chat-messages'));
+                this.messages = messages;
+                const inputArea = append(root, $('.simple-chat-input'));
+                this.input = new InputBox(inputArea, this.contextViewService, { ariaLabel: localize('simpleChatInput', 'Chat input') });
+                const button = append(inputArea, $('button.simple-chat-send', undefined, localize('simpleChatSend', 'Send')));
+                button.addEventListener('click', () => this.submit());
+                this.input.inputElement.addEventListener('keydown', (e) => {
+                        if (e.key === 'Enter') {
+                                e.preventDefault();
+                                this.submit();
+                        }
+                });
+        }
+
+        private async submit(): Promise<void> {
+                const value = this.input.value.trim();
+                if (!value) {
+                        return;
+                }
+
+                this.addMessage(value, 'user');
+                this.input.value = '';
+
+                const start = Date.now();
+                try {
+                        const response = await this.fakeApi(value);
+                        const latency = Date.now() - start;
+                        this.addMarkdownMessage(response, latency);
+                } catch (err) {
+                        this.addMessage(localize('simpleChatError', 'Error: {0}', (err as Error).message ?? String(err)), 'error');
+                }
+
+                this.messages.scrollTop = this.messages.scrollHeight;
+        }
+
+        private addMessage(text: string, cls: string): void {
+                append(this.messages, $('.simple-chat-message.' + cls, undefined, text));
+        }
+
+        private addMarkdownMessage(md: string, latency: number): void {
+                const container = append(this.messages, $('.simple-chat-message.response'));
+                const rendered = this.renderer.render({ value: md });
+                container.appendChild(rendered.element);
+                append(container, $('.simple-chat-latency', undefined, localize('simpleChatLatency', 'Latency: {0}ms', latency)));
+        }
+
+        private async fakeApi(prompt: string): Promise<string> {
+                return new Promise((resolve, reject) => {
+                        const delay = 200 + Math.floor(Math.random() * 800);
+                        setTimeout(() => {
+                                if (/error/i.test(prompt)) {
+                                        reject(new Error('Simulated error'));
+                                } else {
+                                        resolve(`You said: **${prompt}**\n\n\u0060\u0060\u0060ts\nconsole.log('code');\n\u0060\u0060\u0060`);
+                                }
+                        }, delay);
+                });
+        }
+}


### PR DESCRIPTION
## Summary
- add simple chat view with input box and scrollable messages
- render markdown responses with code highlighting
- show latency and error states for API responses

## Testing
- `npm run test-node` *(fails: mocha not found)*
- `npm install mocha` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a264d729388322865c05049045eb9e