### PR TITLE
Handle chat session persistence and streaming

### DIFF
--- a/src/services/chat/session.test.ts
+++ b/src/services/chat/session.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { submitPrompt, loadHistory } from './session.ts';
+import type { ChatMessage } from '../openai/client.ts';
+
+test('submitPrompt builds context, streams, and persists', async () => {
+  const store: Record<string, string> = {};
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; }
+  };
+
+  let builtPrompt = '';
+  const build = async (prompt: string) => {
+    builtPrompt = prompt;
+    return 'CTX:' + prompt;
+  };
+
+  const sent: ChatMessage[][] = [];
+  const send = async (msgs: ChatMessage[], onToken?: (t: string) => void) => {
+    sent.push(msgs);
+    onToken?.('a');
+    onToken?.('b');
+    return { role: 'assistant', content: 'ab' } as ChatMessage;
+  };
+
+  let tokens = '';
+  const res = await submitPrompt('hi', { build, send, onToken: t => tokens += t });
+
+  assert.equal(builtPrompt, 'hi');
+  assert.equal(tokens, 'ab');
+  assert.equal(res.content, 'ab');
+  assert.equal(sent[0][sent[0].length - 1].content, 'CTX:hi');
+
+  const history = loadHistory();
+  assert.deepEqual(history, [
+    { role: 'user', content: 'hi' },
+    { role: 'assistant', content: 'ab' }
+  ]);
+});

--- a/src/services/chat/session.ts
+++ b/src/services/chat/session.ts
@@ -1,0 +1,55 @@
+import { ChatMessage, sendChat } from '../openai/client.ts';
+import { buildPromptWithContext } from '../context/context.ts';
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+const memoryStore: Record<string, string> = {};
+const storage: StorageLike = (globalThis as any)?.localStorage ?? {
+  getItem: key => key in memoryStore ? memoryStore[key] : null,
+  setItem: (key, value) => { memoryStore[key] = value; }
+};
+
+const HISTORY_KEY = 'chatHistory';
+
+export function loadHistory(): ChatMessage[] {
+  try {
+    const raw = storage.getItem(HISTORY_KEY);
+    return raw ? JSON.parse(raw) as ChatMessage[] : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(history: ChatMessage[]): void {
+  try {
+    storage.setItem(HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export async function submitPrompt(
+  prompt: string,
+  options: {
+    editors?: readonly any[];
+    onToken?: (token: string) => void;
+    build?: typeof buildPromptWithContext;
+    send?: typeof sendChat;
+  } = {}
+): Promise<ChatMessage> {
+  const { editors, onToken, build = buildPromptWithContext, send = sendChat } = options;
+  const history = loadHistory();
+  history.push({ role: 'user', content: prompt });
+  saveHistory(history);
+
+  const promptWithContext = await build(prompt, editors);
+  const messages = [...history.slice(0, -1), { role: 'user', content: promptWithContext }];
+  const response = await send(messages, onToken);
+
+  history.push(response);
+  saveHistory(history);
+  return response;
+}

--- a/src/services/openai/client.test.ts
+++ b/src/services/openai/client.test.ts
@@ -35,8 +35,10 @@ test('sendChat parses streaming responses', async () => {
   const response = new Response(stream, { headers: { 'content-type': 'text/event-stream' } });
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => response;
-  const res = await sendChat([{ role: 'user', content: 'Hi' }]);
+  let streamed = '';
+  const res = await sendChat([{ role: 'user', content: 'Hi' }], t => streamed += t);
   assert.equal(res.content, 'Hello');
+  assert.equal(streamed, 'Hello');
   globalThis.fetch = originalFetch;
 });
 

--- a/src/services/openai/client.ts
+++ b/src/services/openai/client.ts
@@ -22,7 +22,10 @@ export class OpenAIError extends Error {
 const API_URL = 'https://api.openai.com/v1/chat/completions';
 const API_KEY = process.env.VITE_OPENAI_API_KEY;
 
-export async function sendChat(messages: ChatMessage[]): Promise<ChatResponse> {
+export async function sendChat(
+  messages: ChatMessage[],
+  onToken?: (token: string) => void
+): Promise<ChatResponse> {
   try {
     const res = await fetch(API_URL, {
       method: 'POST',
@@ -68,7 +71,10 @@ export async function sendChat(messages: ChatMessage[]): Promise<ChatResponse> {
             try {
               const json = JSON.parse(data);
               const delta = json.choices?.[0]?.delta?.content;
-              if (delta) message += delta;
+              if (delta) {
+                message += delta;
+                onToken?.(delta);
+              }
             } catch {
               // ignore parse errors
             }
@@ -81,7 +87,10 @@ export async function sendChat(messages: ChatMessage[]): Promise<ChatResponse> {
             try {
               const json = JSON.parse(data);
               const delta = json.choices?.[0]?.delta?.content;
-              if (delta) message += delta;
+              if (delta) {
+                message += delta;
+                onToken?.(delta);
+              }
             } catch {
               // ignore
             }


### PR DESCRIPTION
## Summary
- allow `sendChat` to stream tokens via callback
- add chat session helper that stores history in local storage and builds context before chat requests
- cover chat session and streaming behavior with tests

## Testing
- `npm test` *(fails: Please run any of the test scripts from the scripts folder.)*
- `node --test src/services/openai/client.test.ts` *(fails: Unknown file extension ".ts" for ...)*
- `node --test src/services/context/context.test.ts` *(fails: Cannot find package 'ts-node')*
- `npm install --no-save ts-node typescript` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a26b0a739883228017548655fef58b