### PR TITLE
feat: add chat file and search commands

### DIFF
--- a/docs/chat/commands.md
+++ b/docs/chat/commands.md
@@ -1,0 +1,8 @@
+# Chat Commands
+
+VS Code Chat supports slash commands for quick actions.
+
+- `/file <path>` – Insert the contents of a workspace file.
+- `/search <query>` – Run a ripgrep search in the current workspace and display the results.
+- `/clear` – Start a new chat session.
+- `/help` – List available chat agents and their commands.


### PR DESCRIPTION
## Summary
- add `/file` slash command to print a file's contents in chat
- add `/search` slash command to run ripgrep via the workspace search service
- document chat commands

## Testing
- `npm test`
- `npm run compile-check-ts-native` *(fails: tsgo not found)*
- `npm run compile` *(fails: Cannot find module 'gulp-filter')*

------
https://chatgpt.com/codex/tasks/task_e_68a272de530c8322af2f007f988ad2e1