### PR TITLE
docs: replace yarn commands with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Visual Studio Code is a lightweight yet powerful source code editor built with w
 1. **Install dependencies**
 
    ```
-   yarn
+   npm install
    ```
 
 2. **Compile and watch for changes**
 
    ```
-   yarn watch
+   npm run watch
    ```
 
 3. **Launch the editor**

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,9 +10,9 @@ This document describes how to build and publish signed releases for VS Code.
 ## Build and Test
 The [release workflow](../.github/workflows/release.yml) runs automatically for tags and on demand. It:
 
-1. Installs dependencies with `yarn --frozen-lockfile`.
+1. Installs dependencies with `npm ci`.
 2. Runs unit tests using `npm test`.
-3. Builds the product with `yarn gulp vscode-{platform}` for:
+3. Builds the product with `npm run gulp vscode-{platform}` for:
    - `win32-x64` on Windows
    - `darwin` on macOS
    - `linux-x64` on Linux

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,7 +3,7 @@
 Install the following tools before working with this repository:
 
 - **Node.js 22.17.0** – specified in `.nvmrc` and required for building.
-- **Yarn** – used to manage Node.js dependencies.
+- **npm** – used to manage Node.js dependencies (bundled with Node.js).
 - **Python 3** – required for native build scripts.
 - **C/C++ build tools**
   - Linux: `gcc`, `g++`, `make`, and related packages (e.g. `build-essential`).
@@ -13,9 +13,9 @@ Install the following tools before working with this repository:
 With the prerequisites installed, install dependencies and start a development build:
 
 ```bash
-yarn
-yarn watch
-yarn web
+npm install
+npm run watch
+npm run web
 ```
 
 ## Environment Variables


### PR DESCRIPTION
## Summary
- use npm install and npm run watch in README
- replace yarn commands with npm equivalents in setup and release docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61da7a66083229c8225e3a332f734