### PR TITLE
feat: add prompt processor and tests

### DIFF
--- a/src/chat/promptProcessor.ts
+++ b/src/chat/promptProcessor.ts
@@ -1,0 +1,49 @@
+export interface PromptMeta {
+    /** The original user input */
+    original: string;
+    /** Simple whitespace tokenization */
+    tokens: string[];
+    /** Basic intent classification */
+    intent: 'search' | 'summarize' | 'unknown';
+}
+
+export interface WorkspaceContext {
+    /** Optional text summaries relevant to the prompt */
+    summaries?: string[];
+    /** File paths that may be relevant for search */
+    filePaths?: string[];
+    /** Suggested follow up actions or hints */
+    suggestions?: string[];
+}
+
+/**
+ * Tokenize the prompt and attempt to classify its intent.
+ */
+export function analyzePrompt(input: string): PromptMeta {
+    const tokens = input.trim().split(/\s+/).filter(Boolean);
+    const normalized = input.toLowerCase();
+    let intent: PromptMeta['intent'] = 'unknown';
+    if (/\b(search|find|lookup)\b/.test(normalized)) {
+        intent = 'search';
+    } else if (/\b(summarize|summary|summarise)\b/.test(normalized)) {
+        intent = 'summarize';
+    }
+    return { original: input, tokens, intent };
+}
+
+/**
+ * Enhance the prompt with additional context information.
+ */
+export function enhancePrompt(meta: PromptMeta, context: WorkspaceContext): string {
+    let enhanced = meta.original;
+    if (meta.intent === 'summarize' && context.summaries && context.summaries.length) {
+        enhanced += '\n\nSummaries:\n' + context.summaries.join('\n');
+    }
+    if (meta.intent === 'search' && context.filePaths && context.filePaths.length) {
+        enhanced += '\n\nFiles:\n' + context.filePaths.join('\n');
+    }
+    if (context.suggestions && context.suggestions.length) {
+        enhanced += '\n\nSuggestions:\n' + context.suggestions.join('\n');
+    }
+    return enhanced;
+}

--- a/src/chat/test/promptProcessor.test.ts
+++ b/src/chat/test/promptProcessor.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from 'assert';
+import test from 'node:test';
+import { analyzePrompt, enhancePrompt } from '../promptProcessor';
+
+test('classifies search intent', () => {
+    const meta = analyzePrompt('search for foo');
+    assert.equal(meta.intent, 'search');
+    assert.deepEqual(meta.tokens, ['search', 'for', 'foo']);
+});
+
+test('classifies summarize intent', () => {
+    const meta = analyzePrompt('please summarize this file');
+    assert.equal(meta.intent, 'summarize');
+});
+
+test('defaults to unknown intent', () => {
+    const meta = analyzePrompt('hello world');
+    assert.equal(meta.intent, 'unknown');
+});
+
+test('enhances search prompt with files and suggestions', () => {
+    const meta = analyzePrompt('search errors');
+    const enhanced = enhancePrompt(meta, { filePaths: ['src/a.ts', 'src/b.ts'], suggestions: ['check logs'] });
+    assert.ok(enhanced.includes('src/a.ts'));
+    assert.ok(enhanced.includes('Suggestions:'));
+});
+
+test('enhances summarize prompt with summaries', () => {
+    const meta = analyzePrompt('summarize project');
+    const enhanced = enhancePrompt(meta, { summaries: ['Summary A'] });
+    assert.ok(enhanced.includes('Summary A'));
+});


### PR DESCRIPTION
## Summary
- add prompt processor for tokenization and intent detection
- support enhancing prompts with summaries, file paths, and suggestions
- cover classification and enhancement logic with unit tests

## Testing
- `npx mocha -r ts-node/register src/chat/test/promptProcessor.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mocha)*
- `node --test src/chat/test/promptProcessor.test.ts` *(fails: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for promptProcessor.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f8ca5e883228dd7176f9a2fd09a