### PR TITLE
feat: add chat panel and openai integration

### DIFF
--- a/src/chat/services/contextCollector.ts
+++ b/src/chat/services/contextCollector.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import { WorkspaceContext } from '../promptProcessor';
+
+/**
+ * Collect context from visible text editors. For each open editor we include
+ * its file path and either the current selection or the first ~200 lines of
+ * the file.
+ */
+export async function collectContext(): Promise<WorkspaceContext> {
+    const editors = vscode.window.visibleTextEditors;
+    const filePaths: string[] = [];
+    const summaries: string[] = [];
+
+    for (const editor of editors) {
+        const doc = editor.document;
+        filePaths.push(doc.uri.fsPath);
+        let text: string;
+        if (editor.selection && !editor.selection.isEmpty) {
+            text = doc.getText(editor.selection);
+        } else {
+            const maxLine = Math.min(200, doc.lineCount);
+            text = doc.getText(new vscode.Range(0, 0, maxLine, 0));
+        }
+        const lines = text.split(/\r?\n/).slice(0, 200);
+        summaries.push(`File: ${doc.uri.fsPath}\n${lines.join('\n')}`);
+    }
+
+    return { filePaths, summaries };
+}

--- a/src/chat/services/openaiClient.ts
+++ b/src/chat/services/openaiClient.ts
@@ -1,0 +1,65 @@
+export interface ChatMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+}
+
+/**
+ * Send chat messages to OpenAI's Chat Completions API using the
+ * environment variable `OPENAI_API_KEY` for authentication. The
+ * response is streamed and yielded chunk by chunk.
+ */
+export async function* sendChat(messages: ChatMessage[]): AsyncGenerator<string> {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+        throw new Error('OPENAI_API_KEY is not set');
+    }
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            stream: true,
+            messages
+        })
+    });
+
+    if (!response.ok || !response.body) {
+        throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+            break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('data:')) {
+                continue;
+            }
+            const data = trimmed.replace(/^data:\s*/, '');
+            if (data === '[DONE]') {
+                return;
+            }
+            try {
+                const json = JSON.parse(data);
+                const text = json.choices?.[0]?.delta?.content;
+                if (text) {
+                    yield text;
+                }
+            } catch {
+                // ignore malformed JSON chunks
+            }
+        }
+    }
+}

--- a/src/chat/ui/panel.ts
+++ b/src/chat/ui/panel.ts
@@ -1,0 +1,122 @@
+import * as vscode from 'vscode';
+import { analyzePrompt, enhancePrompt } from '../promptProcessor';
+import { collectContext } from '../services/contextCollector';
+import { sendChat, ChatMessage } from '../services/openaiClient';
+
+export class ChatPanel {
+    private static current?: ChatPanel;
+    private readonly panel: vscode.WebviewPanel;
+    private readonly disposables: vscode.Disposable[] = [];
+    private assistantBuffer = '';
+
+    public static createOrShow(extensionUri: vscode.Uri) {
+        const column = vscode.window.activeTextEditor?.viewColumn;
+        if (ChatPanel.current) {
+            ChatPanel.current.panel.reveal(column);
+        } else {
+            const panel = vscode.window.createWebviewPanel(
+                'chatPanel',
+                'Chat',
+                column ?? vscode.ViewColumn.One,
+                { enableScripts: true }
+            );
+            ChatPanel.current = new ChatPanel(panel, extensionUri);
+        }
+    }
+
+    private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+        this.panel = panel;
+        this.panel.webview.html = this.getHtml(this.panel.webview, extensionUri);
+        this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+        this.panel.webview.onDidReceiveMessage((m) => this.handleMessage(m), null, this.disposables);
+    }
+
+    private getHtml(webview: vscode.Webview, extensionUri: vscode.Uri): string {
+        const nonce = getNonce();
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdn.jsdelivr.net;">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chat</title>
+</head>
+<body>
+    <div id="messages"></div>
+    <form id="form">
+        <textarea id="input" rows="3"></textarea>
+        <button type="submit">Send</button>
+    </form>
+    <script nonce="${nonce}" src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script nonce="${nonce}">
+        const vscode = acquireVsCodeApi();
+        const form = document.getElementById('form');
+        const input = document.getElementById('input');
+        const messages = document.getElementById('messages');
+        let assistantDiv = null;
+
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const value = input.value;
+            input.value = '';
+            const div = document.createElement('div');
+            div.textContent = '> ' + value;
+            messages.appendChild(div);
+            assistantDiv = document.createElement('div');
+            messages.appendChild(assistantDiv);
+            vscode.postMessage({ type: 'chat', text: value });
+        });
+
+        window.addEventListener('message', event => {
+            const msg = event.data;
+            if (msg.type === 'response' && assistantDiv) {
+                assistantDiv.innerHTML = marked.parse(msg.text);
+            }
+        });
+    </script>
+</body>
+</html>`;
+    }
+
+    private async handleMessage(message: any) {
+        if (message.type === 'chat') {
+            await this.processChat(message.text);
+        }
+    }
+
+    private async processChat(input: string) {
+        const context = await collectContext();
+        const meta = analyzePrompt(input);
+        const enhanced = enhancePrompt(meta, context);
+        const msgs: ChatMessage[] = [{ role: 'user', content: enhanced }];
+        this.assistantBuffer = '';
+        try {
+            for await (const chunk of sendChat(msgs)) {
+                this.assistantBuffer += chunk;
+                this.panel.webview.postMessage({ type: 'response', text: this.assistantBuffer });
+            }
+        } catch (err: any) {
+            this.panel.webview.postMessage({ type: 'response', text: `Error: ${err.message}` });
+        }
+    }
+
+    public dispose() {
+        ChatPanel.current = undefined;
+        this.panel.dispose();
+        while (this.disposables.length) {
+            const d = this.disposables.pop();
+            if (d) {
+                d.dispose();
+            }
+        }
+    }
+}
+
+function getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,38 +1,39 @@
 {
-	"extends": "./tsconfig.base.json",
-	"compilerOptions": {
-		"esModuleInterop": true,
-		"removeComments": false,
-		"preserveConstEnums": true,
-		"sourceMap": false,
-		"allowJs": true,
-		"resolveJsonModule": true,
-		"isolatedModules": false,
-		"outDir": "../out/vs",
-		"types": [
-			"@webgpu/types",
-			"mocha",
-			"semver",
-			"sinon",
-			"trusted-types",
-			"winreg",
-			"wicg-file-system-access"
-		],
-		"plugins": [
-			{
-				"name": "tsec",
-				"exemptionConfig": "./tsec.exemptions.json"
-			}
-		]
-	},
-	"include": [
-		"./*.ts",
-		"./typings",
-		"./vs/**/*.ts",
-		"./vscode-dts/vscode.proposed.*.d.ts",
-		"./vscode-dts/vscode.d.ts"
-	],
-	"exclude": [
-		"vs/workbench/contrib/webview/browser/pre/service-worker.js"
-	]
+        "extends": "./tsconfig.base.json",
+        "compilerOptions": {
+                "esModuleInterop": true,
+                "removeComments": false,
+                "preserveConstEnums": true,
+                "sourceMap": false,
+                "allowJs": true,
+                "resolveJsonModule": true,
+                "isolatedModules": false,
+                "outDir": "../out/vs",
+                "types": [
+                        "@webgpu/types",
+                        "mocha",
+                        "semver",
+                        "sinon",
+                        "trusted-types",
+                        "winreg",
+                        "wicg-file-system-access"
+                ],
+                "plugins": [
+                        {
+                                "name": "tsec",
+                                "exemptionConfig": "./tsec.exemptions.json"
+                        }
+                ]
+        },
+        "include": [
+                "./*.ts",
+                "./typings",
+                "./vs/**/*.ts",
+                "./chat/**/*.ts",
+                "./vscode-dts/vscode.proposed.*.d.ts",
+                "./vscode-dts/vscode.d.ts"
+        ],
+        "exclude": [
+                "vs/workbench/contrib/webview/browser/pre/service-worker.js"
+        ]
 }


### PR DESCRIPTION
## Summary
- connect to OpenAI chat completions using `OPENAI_API_KEY` and stream results
- collect open editor context and selections for prompt enhancement
- add webview chat panel with message history and markdown rendering
- wire UI to gather context and display streaming responses

## Testing
- `npm test`
- `node --test src/chat/test/promptProcessor.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_68a692e673dc8322b0130004fb607792