### PR TITLE
feat: add debug logging and tests

### DIFF
--- a/docs/chat/debugging.md
+++ b/docs/chat/debugging.md
@@ -1,0 +1,19 @@
+# Debugging Chat Integration
+
+This guide covers common issues when using the chat features.
+
+## Missing API Key
+- **Error**: `OPENAI_API_KEY is not set` or `401 Unauthorized`.
+- **Fix**: Ensure the `OPENAI_API_KEY` environment variable is configured before starting VS Code.
+
+## Network Failures
+- **Error**: `fetch failed` or timeouts when contacting OpenAI.
+- **Fix**: Check your internet connection or proxy settings. Retry once connectivity is restored.
+
+## Rate Limits
+- **Error**: Responses indicating too many requests.
+- **Fix**: Reduce request frequency or upgrade your OpenAI plan.
+
+## Context Collection
+- **Issue**: No context gathered from open editors.
+- **Fix**: Make sure files are open and visible. Selections take precedence; otherwise the first 200 lines are used.

--- a/src/chat/services/contextCollector.ts
+++ b/src/chat/services/contextCollector.ts
@@ -11,9 +11,12 @@ export async function collectContext(): Promise<WorkspaceContext> {
     const filePaths: string[] = [];
     const summaries: string[] = [];
 
+    console.debug('[chat] collecting context from', editors.length, 'editors');
+
     for (const editor of editors) {
         const doc = editor.document;
         filePaths.push(doc.uri.fsPath);
+        console.debug('[chat] collecting context for', doc.uri.fsPath);
         let text: string;
         if (editor.selection && !editor.selection.isEmpty) {
             text = doc.getText(editor.selection);
@@ -25,5 +28,6 @@ export async function collectContext(): Promise<WorkspaceContext> {
         summaries.push(`File: ${doc.uri.fsPath}\n${lines.join('\n')}`);
     }
 
+    console.debug('[chat] collected context for files', filePaths);
     return { filePaths, summaries };
 }

--- a/tests/chat.integration.test.ts
+++ b/tests/chat.integration.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sendChat } from '../src/services/openai/client.ts';
+import { ReadableStream } from 'node:stream/web';
+
+const encoder = new TextEncoder();
+function streamFromLines(lines: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line));
+      }
+      controller.close();
+    }
+  });
+}
+
+test('sendChat logs usage and timing when DEBUG_CHAT=1', async () => {
+  process.env.DEBUG_CHAT = '1';
+  const lines = [
+    'data: {"choices":[{"delta":{"content":"Hel"}}]}\n',
+    'data: {"choices":[{"delta":{"content":"lo"}}]}\n',
+    'data: {"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}\n',
+    'data: [DONE]\n'
+  ];
+  const stream = streamFromLines(lines);
+  const response = new Response(stream, { headers: { 'content-type': 'text/event-stream' } });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => response as any;
+  const logs: string[] = [];
+  const originalDebug = console.debug;
+  console.debug = (...args: any[]) => { logs.push(args.join(' ')); };
+  const res = await sendChat([{ role: 'user', content: 'Hi' }]);
+  console.debug = originalDebug;
+  globalThis.fetch = originalFetch;
+  assert.equal(res.content, 'Hello');
+  assert(logs.some(l => l.includes('tokens')));
+  assert(logs.some(l => l.includes('duration')));
+  delete process.env.DEBUG_CHAT;
+});


### PR DESCRIPTION
## Summary
- add verbose debug logging to chat API calls and context collection
- support DEBUG_CHAT env flag to report token usage and timing
- document chat troubleshooting steps

## Testing
- `npm test` *(fails: Please run any of the test scripts from the scripts folder.)*
- `node --test tests/chat.integration.test.ts` *(fails: Unknown file extension ".ts")*

------
https://chatgpt.com/codex/tasks/task_e_68a695c78484832290764a5ce3dce488