### PR TITLE
docs: document setup commands and sample env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-VITE_OPENAI_API_KEY=
-VITE_OPENAI_MODEL=gpt-5-2025-08-07
+# Sample environment variables for VS Code chat
+VITE_OPENAI_API_KEY=your-api-key
+VITE_OPENAI_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -21,14 +21,25 @@ Visual Studio Code is a lightweight yet powerful source code editor built with w
    npm run watch
    ```
 3. **Launch the editor**
-   ```
-   ./scripts/code.sh
-   ```
+   - Desktop:
+     ```
+     npm run start
+     ```
+   - Browser:
+     ```
+     npm run web
+     ```
 
 ## Chat Usage
 Use the chat bar at the bottom of the editor to ask questions, run commands, or get code suggestions.
 
 ![Chat bar screenshot](docs/chat/chat-bar.svg)
+
+## Manual Test
+1. Open the chat view from the Activity Bar.
+2. Ask **"Summarize open file"**.
+3. Ensure the assistant responds with a summary of the active file.
+4. If something goes wrong, please file an issue with logs and reproduction steps.
 
 ## Future Work
 Planned enhancements include:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,7 +15,8 @@ With the prerequisites installed, install dependencies and start a development b
 ```bash
 npm install
 npm run watch
-npm run web
+npm run start   # desktop
+npm run web     # browser
 ```
 
 ## Environment Variables
@@ -27,4 +28,11 @@ cp .env.example .env
 ```
 
 Never commit real API keys or secrets. Load variables from this file with a library such as [`dotenv`](https://www.npmjs.com/package/dotenv) or your build tooling.
+
+## Manual Test
+
+1. Open the chat view from the Activity Bar.
+2. Ask **"Summarize open file"**.
+3. Confirm the assistant returns a summary of the active file.
+4. If you encounter issues, please file an issue with logs and reproduction steps.
 


### PR DESCRIPTION
## Summary
- document npm install/watch/start/web in setup guides
- add sample `.env.example` for OpenAI key and model
- describe manual chat test and encourage issue filing

## Testing
- `npm test` *(fails: Please run any of the test scripts from the scripts folder)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ae5ab608322889a8340fd73ac08