### PR TITLE
feat: show chat container on startup

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,6 +19,10 @@ npm run start   # desktop
 npm run web     # browser
 ```
 
+After starting the editor, the Chat icon is now visible in the Activity Bar
+by default. Click the icon to open the chat view without using the Command
+Palette.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and set your local values:
@@ -31,7 +35,7 @@ Never commit real API keys or secrets. Load variables from this file with a libr
 
 ## Manual Test
 
-1. Open the chat view from the Activity Bar.
+1. Click the Chat icon in the Activity Bar to open the chat view.
 2. Ask **"Summarize open file"**.
 3. Confirm the assistant returns a summary of the active file.
 4. If you encounter issues, please file an issue with logs and reproduction steps.

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -40,7 +40,9 @@ const chatViewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(Vi
 	icon: Codicon.commentDiscussion,
 	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [CHAT_SIDEBAR_PANEL_ID, { mergeViewWithContainerWhenSingleView: true }]),
 	storageId: CHAT_SIDEBAR_PANEL_ID,
-	hideIfEmpty: true,
+        // Show the chat container even if no views are registered yet so the
+        // Chat icon is visible on first launch.
+        hideIfEmpty: false,
 	order: 100,
 }, ViewContainerLocation.AuxiliaryBar, { isDefault: true, doNotRegisterOpenCommand: true });
 


### PR DESCRIPTION
## Summary
- show Chat view container even when empty so its icon is visible on first launch
- document that the Chat icon now appears in the Activity Bar by default

## Testing
- `npm run watch` *(fails: npm-run-all: not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a719c4ce508322beff152ee0dbd73c