### PR TITLE
Register simple chat view with unique descriptor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/simpleChat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/simpleChat.contribution.ts
@@ -7,7 +7,6 @@ import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContaine
 import { SimpleChatViewPane } from './simpleChatView.js';
 
 export const SIMPLE_CHAT_VIEW_CONTAINER_ID = 'workbench.view.simpleChat';
-export const SIMPLE_CHAT_VIEW_ID = 'workbench.view.simpleChat.view';
 
 const viewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
         id: SIMPLE_CHAT_VIEW_CONTAINER_ID,
@@ -19,7 +18,7 @@ const viewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewCo
 
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([
         {
-                id: SIMPLE_CHAT_VIEW_ID,
+                id: SimpleChatViewPane.ID,
                 name: localize('simpleChatView', "Simple Chat"),
                 ctorDescriptor: new SyncDescriptor(SimpleChatViewPane),
                 canMoveView: true,

--- a/src/vs/workbench/contrib/chat/browser/simpleChatView.ts
+++ b/src/vs/workbench/contrib/chat/browser/simpleChatView.ts
@@ -18,6 +18,8 @@ import { inputBackground, inputForeground, inputBorder } from '../../../../platf
 import './media/simpleChat.css';
 
 export class SimpleChatViewPane extends ViewPane {
+        static readonly ID = 'workbench.view.simpleChat.view';
+
         private messages!: HTMLElement;
         private input!: InputBox;
         private renderer: ChatMarkdownRenderer;


### PR DESCRIPTION
## Summary
- declare a stable ID on `SimpleChatViewPane`
- register the simple chat view descriptor with the sidebar container using that ID

## Testing
- `npm test`
- `npm run -s compile` *(fails: Cannot find module '/workspace/vscode/node_modules/gulp/bin/gulp.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a79479ae2c8322b4d549b8284c7313