### PR TITLE
Add Fancy Chat extension activation and build plumbing

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -34,6 +34,7 @@ const compilations = [
 'extensions/curated-sample/tsconfig.json',
 'extensions/debug-auto-launch/tsconfig.json',
 'extensions/debug-server-ready/tsconfig.json',
+	'extensions/fancy-chat/tsconfig.json',
 	'extensions/emmet/tsconfig.json',
 	'extensions/extension-editing/tsconfig.json',
 	'extensions/git/tsconfig.json',
@@ -74,6 +75,10 @@ const compilations = [
 	'.vscode/extensions/vscode-selfhost-import-aid/tsconfig.json',
 ];
 
+const extensionSourceOverrides = new Map([
+	['extensions/fancy-chat/tsconfig.json', 'src/chat']
+]);
+
 const getBaseUrl = out => `https://main.vscode-cdn.net/sourcemaps/${commit}/${out}`;
 
 const tasks = compilations.map(function (tsconfigFile) {
@@ -86,7 +91,8 @@ const tasks = compilations.map(function (tsconfigFile) {
 	const name = relativeDirname.replace(/\//g, '-');
 
 	const srcRoot = path.dirname(tsconfigFile);
-	const srcBase = path.join(srcRoot, 'src');
+	const srcBaseOverride = extensionSourceOverrides.get(tsconfigFile);
+	const srcBase = srcBaseOverride ? path.join(root, srcBaseOverride) : path.join(srcRoot, 'src');
 	const src = path.join(srcBase, '**');
 	const srcOpts = { cwd: root, base: srcBase, dot: true };
 

--- a/extensions/fancy-chat/package.json
+++ b/extensions/fancy-chat/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "vscode": "^1.96.0"
   },
-  "main": "../../out/vs/chat/extension.js",
+  "main": "./out/chat/extension.js",
   "activationEvents": [
     "onCommand:fancyChat.openPanel"
   ],

--- a/extensions/fancy-chat/tsconfig.json
+++ b/extensions/fancy-chat/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out",
+    "rootDir": "../../src",
+    "resolveJsonModule": true,
+    "lib": [
+      "ES2024",
+      "DOM"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types"
+    ]
+  },
+  "include": [
+    "../../src/chat/**/*.ts",
+    "../../src/vscode-dts/vscode.d.ts"
+  ],
+  "exclude": [
+    "../../src/chat/test/**/*"
+  ]
+}

--- a/src/chat/extension.ts
+++ b/src/chat/extension.ts
@@ -1,14 +1,20 @@
 import * as vscode from 'vscode';
 import { ChatPanel } from './ui/panel';
 
+const disposables: vscode.Disposable[] = [];
+
 export function activate(context: vscode.ExtensionContext): void {
-    const disposable = vscode.commands.registerCommand('fancyChat.openPanel', () => {
+    const commandDisposable = vscode.commands.registerCommand('fancyChat.openPanel', () => {
         ChatPanel.createOrShow(context.extensionUri);
     });
 
-    context.subscriptions.push(disposable);
+    context.subscriptions.push(commandDisposable);
+    disposables.push(commandDisposable);
 }
 
 export function deactivate(): void {
-    // Nothing to clean up explicitly; disposables are handled by VS Code
+    while (disposables.length) {
+        const disposable = disposables.pop();
+        disposable?.dispose();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the Fancy Chat activation command registers cleanly and disposes registered resources when the extension unloads
- ship Fancy Chat as a self-contained built-in extension by pointing its manifest at `./out/chat/extension.js`, adding a tsconfig that builds the shared chat sources into the extension folder, and wiring that project into the gulp extension compilation pipeline

## Testing
- ⚠️ `npx gulp compile-extension:fancy-chat` *(fails to download gulp from the public npm registry in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df07bfa248322879e417623f02f79)